### PR TITLE
イベント、プロフィール指摘箇所修正

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,5 @@
 class Event < ApplicationRecord
-  validates_datetime :hold_date
+  validates_datetime :hold_date, :on_or_after => lambda { Date.today }
   
   validates :name, presence: true
   validates :place, presence: true

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <div class="form-group">
-      <%= form.label :name %>
+      <%= form.label :name %>&nbsp;<em><font size="-1">(英数字のみ利用可能です)</font></em>
       <%= form.text_field :name, id: :user_name, class: "form-control" %>
     </div>
 

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <div class="form-group">
-      <%= form.label :name %><em><font size="-1">(英数字のみ利用可能です)</font></em>
+      <%= form.label :name %>&nbsp;<em><font size="-1">(英数字のみ利用可能です)</font></em>
       <%= form.text_field :name, id: :user_name, class: "form-control" %>
     </div>
 
@@ -24,7 +24,7 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :password %>
+      <%= form.label :password %>&nbsp;<em><font size="-1">(6文字以上)</font></em>
       <%= form.password_field :password, id: :user_password, class: "form-control" %>
     </div>
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="form-group">
     <%= form.label :hold_date %>
     <div class="input-group date" id="datetimepicker1" data-target-input="nearest">
-      <%= form.text_field :hold_date, id: :event_hold_date, class: "form-control datepicker", data: { target: '#event_hold_date'} %>
+      <%= form.text_field :hold_date, id: :event_hold_date, class: "form-control datepicker", data: { target: '#event_hold_date'}, placeholder: "年/月/日 時:分"%>
       <div class="input-group-append" data-target="#event_hold_date" data-toggle="datetimepicker">
         <div class="input-group-text"><i class="fa fa-calendar"></i></div>
       </div>
@@ -42,7 +42,7 @@
 
   <div class="form-group">
     <%= form.label :url %>
-    <%= form.url_field :url, id: :event_url, class: "form-control" %>
+    <%= form.url_field :url, id: :event_url, class: "form-control", placeholder: "https://" %>
   </div><br>
 
   <div class="actions" align="center">

--- a/app/views/events/confirm.html.erb
+++ b/app/views/events/confirm.html.erb
@@ -12,7 +12,7 @@
       <table class="table" width="100%">
         <tr>
           <td><%= t('view.event_hold_date') %></td>
-          <td><%= @event.hold_date %></td>
+          <td><%= @event.hold_date.to_s(:event_date) %></td>
         </tr>
 
         <tr>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <div class="form-group">
-      <%= form.label :name %>
+      <%= form.label :name %>&nbsp;<em><font size="-1">(英数字のみ利用可能です)</font></em>
       <%= form.text_field :name, id: :user_name, class: "form-control" %>
     </div>
 
@@ -24,7 +24,7 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :password %>
+      <%= form.label :password %>&nbsp;<em><font size="-1">(6文字以上)</font></em>
       <%= form.password_field :password, id: :user_password, class: "form-control" %>
     </div>
 


### PR DESCRIPTION
#128 

- イベント開催日時のバリデーションを、過去の日付が選択出来ないように修正
- 確認画面でイベント日時がおかしかった箇所を修正
- 名前の入力制限をビューに追加